### PR TITLE
Access primary server from agent using container name

### DIFF
--- a/dependencies/go-agent/init.sh
+++ b/dependencies/go-agent/init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+count=0
+while [ "$count" -lt "60" -a "$(nc -zv primarygo 8153 2>/dev/null; echo $?)" -ne "0" ]; do
+  [[ "$((count % 10))" = "0" ]] && echo "Waiting for primary Go Server to be up ..."
+  sleep 2;
+  count=$((count + 1))
+done
+
+bash -x /docker-entrypoint.sh

--- a/dependencies/go-primary/init.sh
+++ b/dependencies/go-primary/init.sh
@@ -35,7 +35,12 @@ mv -f '/godata/business-continuity-token' '/godata/config/business-continuity-to
 touch /etc/rc.local
 
 echo "Assigning this Go Server machine the virtual IP: 172.17.17.17"
-/gocd-jre/bin/java -Dinterface=eth0:0 -Dip=172.17.17.17 -Dnetmask=255.255.0.0 -jar /godata/addons/go-business-continuity-*.jar assign
+java -Dinterface=eth0:0 -Dip=172.17.17.17 -Dnetmask=255.255.0.0 -jar /godata/addons/go-business-continuity-*.jar assign
+RES = $?
+if [ $RES -ne 0 ]; then
+  echo "Failed to assign Virtual IP to primary server"
+  exit -1
+end
 
 chown -R 1000:1000 /godata/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,11 @@ secondarygo:
 agent1:
   image: gocd-agent-centos-7:gocd-agent-for-bc-test
 
+  command: ["./gostartup/init.sh"]
+
+  volumes:
+    - ./dependencies/go-agent:/gostartup
+
   environment:
-    - GO_SERVER_URL=https://172.17.17.17:8154/go
+    - GO_SERVER_URL=https://primarygo:8154/go
     - AGENT_AUTO_REGISTER_KEY=123456789abcdef


### PR DESCRIPTION
Accessing primary server from agent using virtual IP address fails with NoRouteToHostException on DinD container. The communication via Virtual IP works fine while running this BC setup on a Openstack Linux VM or Mac machine. So as workaround for now added a validation after virtual IP assignment to check if it succeeded and using primary server container name as server_url for agent